### PR TITLE
Remove langchain-milvus dependency and related imports from translati…

### DIFF
--- a/data-upload/translate.ipynb
+++ b/data-upload/translate.ipynb
@@ -9,7 +9,6 @@
    "source": [
     "# connect to milvus db\n",
     "\n",
-    "from langchain_milvus import Milvus\n",
     "from langchain_google_genai import GoogleGenerativeAIEmbeddings\n",
     "from dotenv import load_dotenv\n",
     "from pymilvus import MilvusClient\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ asyncio-throttle>=1.0.2
 
 # Vector database
 pymilvus>=2.3.0
-langchain-milvus>=1.0.0
 
 # Testing
 pytest>=8.0.0

--- a/src/translation_api/utils/translation_compare.py
+++ b/src/translation_api/utils/translation_compare.py
@@ -1,6 +1,5 @@
 # connect to milvus db
 
-from langchain_milvus import Milvus
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 import os
 from dotenv import load_dotenv


### PR DESCRIPTION
…on files

- Deleted the `langchain-milvus` dependency from `requirements.txt` to streamline package requirements.
- Removed import statements for `Milvus` from `translate.ipynb` and `translation_compare.py`, reflecting the updated architecture.